### PR TITLE
:art: Refactor compute volume

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,14 @@ include_directories(
 
 # mpm_point_generator executable
 SET(mpm_point_gen_src
+  src/element.cc
   src/main.cc
 )
 add_executable(mpm_point_generator ${mpm_point_gen_src})
 
 # Unit test
 SET(unit_test_src
+  ${PROJECT_SOURCE_DIR}/src/element.cc  
   ${PROJECT_SOURCE_DIR}/tests/unit_test.cc
   ${PROJECT_SOURCE_DIR}/tests/point_test.cc
   ${PROJECT_SOURCE_DIR}/tests/material_properties_test.cc

--- a/include/element.h
+++ b/include/element.h
@@ -110,6 +110,4 @@ class Element {
   std::vector<Eigen::Vector3d> coordinates_;
 };
 
-#include "element.cc"
-
 #endif  // MPM_ELEMENT_H

--- a/src/element.cc
+++ b/src/element.cc
@@ -1,4 +1,4 @@
-
+#include "element.h"
 
 //! Calculate volume of an element
 //!\retval volume of an element

--- a/tests/volume_test.cc
+++ b/tests/volume_test.cc
@@ -7,23 +7,26 @@
 #include "catch.hpp"
 #include "element.h"
 
-//! \brief Check that IO will store right values
+//! \brief Check the volume of an element computation
 TEST_CASE("GMSH is checked in 3D", "[GMSH][3D]") {
 
   const double tolerance = 1.E-12;
 
-  double test = 0;
+  // Element id
   const unsigned id = 0;
 
-  SECTION("Check volume of hexahedron") {
+  SECTION("Check volume of a hexahedron") {
 
+    // Element coordinates
     std::vector<Eigen::Vector3d> coordinates;
+    // Element vertices
     Eigen::VectorXd vertices(8);
+    vertices.setZero();
 
-    vertices << 0, 0, 0, 0, 0, 0, 0, 0;
-
+    // Create a new element
     Element element(id, vertices);
 
+    // Assign coordinates of vertices
     Eigen::Vector3d a = {0, 0.1, 0.1}, b = {0.05, 0.1, 0.1},
                     c = {0.05, 0.05, 0.1}, d = {0, 0.05, 0.1},
                     e = {0, 0.1, 0.05}, f = {0.05, 0.1, 0.05},
@@ -39,8 +42,7 @@ TEST_CASE("GMSH is checked in 3D", "[GMSH][3D]") {
     coordinates.push_back(h);
 
     element.coordinates(coordinates);
-    test = element.calculate_volume();
 
-    REQUIRE(test == Approx(0.000125).epsilon(tolerance));
+    REQUIRE(element.calculate_volume() == Approx(0.000125).epsilon(tolerance));
   }
 }


### PR DESCRIPTION
Move `element.cc` to `src` and improve element volume test calculation.